### PR TITLE
Hotfix/correcao playbook

### DIFF
--- a/hosts
+++ b/hosts
@@ -1,7 +1,9 @@
-[debian]
-10.0.0.111
-10.0.0.112
+host1 ansible_host=10.0.0.111 ansible_ssh_private_key_file='.vagrant/machines/host1/virtualbox/private_key'
+host2 ansible_host=10.0.0.112 ansible_ssh_private_key_file='.vagrant/machines/host2/virtualbox/private_key'
+host3 ansible_host=10.0.0.110 ansible_ssh_private_key_file='.vagrant/machines/host3/virtualbox/private_key'
 
+[debian]
+host[1:2]
 
 [centos]
-10.0.0.110
+host3

--- a/playbook.yaml
+++ b/playbook.yaml
@@ -3,15 +3,15 @@
   hosts: all
   become: true
   tasks:
-    
+
     - name: Instalando pacotes em sistemas baseados em debian
       apt:
-        name: {{ item }}
+        name: "{{ item }}"
         install_recommends: true
         state: present
-        when: ansible_facts['os_family'] == "Debian"
+      when: ansible_facts['os_family'] == "Debian"
       loop:
-        - git 
+        - git
         - vim
         - htop
 
@@ -19,20 +19,20 @@
       yum:
         name: git
         state: present
-        when: ansible_facts['os_family'] == "centOS"
+      when: ansible_facts['os_family'] == "centOS"
 
 - name: criando um servidor
   hosts: host2
   become: true
   tasks:
-    
+
     - name: Instalando o nginx
       apt:
         name: nginx
         state: present
         install_recommends: no
         update_cache: yes
- 
+
     - name: copiando arquivo de index.html
       copy:
         src: ./files/index.html
@@ -48,8 +48,8 @@
 
 - name: desligando...
   hosts: all
-  tasks: 
-    - name: Desligar máquinas por IP 
+  tasks:
+    - name: Desligar máquinas por IP
       ansible.builtin.command: /sbin/shutdown -t now
       when: (ansible_facts['ansible_default_ipv4.address'] == "10.0.0.111")
 ...


### PR DESCRIPTION
Como a cada provisionamento o vagrant utiliza uma chave ssh diferente, deve-se inserir essa informação no arquivo de inventário.

Outra possível solução para isso, e passar a chave ssh local, comumente localizada em `~/.ssh/id_rsa.pub`, para o arquivo de chaves autorizadas da VM, `~/.ssh/authorized_keys`, no momento do provisionamento.

Além disso, foram realizada correções de sintaxe e estilo no `playbook`

Apenas as últimas tasks não estão funcionando, já que tem uma condicional que depende do IP da máquina, obtendo-o da interface padrão. No entanto, a interface padrão das máquinas está em NAT, não sendo possível definir a condicional de forma adequada.